### PR TITLE
bug fix : gradle.build dependency osdt-core typo

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,7 +59,7 @@ project(':clients') {
         implementation group: 'com.oracle.database.jdbc', name: 'ojdbc11', version: '21.5.0.0'
         implementation group: 'com.oracle.database.messaging', name: 'aqapi', version: '19.3.0.0'
         implementation group: 'com.oracle.database.security', name: 'oraclepki', version: '21.5.0.0'
-        implementation group: 'com.oracle.database.security', name: '`osdt_core`', version: '21.5.0.0'
+        implementation group: 'com.oracle.database.security', name: 'osdt_core', version: '21.5.0.0'
         implementation group: 'com.oracle.database.security', name: 'osdt_cert', version: '21.5.0.0'
         implementation group: 'javax.jms', name: 'javax.jms-api', version: '2.0.1'
         implementation group: 'javax.transaction', name: 'jta', version: '1.1'


### PR DESCRIPTION
fixing issue #7 

Attention: only 1 file was changed removing Backticks from osdt_core declaration. Please review.