### PR TITLE
ER : Update documentation and fix some typos

### DIFF
--- a/clients/src/main/java/org/oracle/okafka/clients/admin/AdminClient.java
+++ b/clients/src/main/java/org/oracle/okafka/clients/admin/AdminClient.java
@@ -42,7 +42,7 @@ import org.oracle.okafka.common.config.ConfigResource;
  * Topic can be created or altered with following configs. If these configs are not overriden by client then server default values are used.
  * 
  * retention.ms: Amount of time in milliseconds messages stay in topic and are available for consumption. In kafka retention time starts after
- * enqueue of a message whereas in TEQ retention starts after all subscribers(goups) of a topic consume a message. In TEQ retention.ms is rounded to seconds. This property is supported on or later 20c database.
+ * enqueue of a message whereas in TEQ retention starts after all subscribers(groups) of a topic consume a message. In TEQ retention.ms is rounded to seconds. This property is supported on or later 20c database.
  *
  */
 @InterfaceStability.Evolving
@@ -327,7 +327,7 @@ public abstract class AdminClient implements AutoCloseable {
     public abstract RenewDelegationTokenResult renewDelegationToken(byte[] hmac, RenewDelegationTokenOptions options);
 
     /**
-     * <This method is not yet supported.
+     * This method is not yet supported.
      */
     public ExpireDelegationTokenResult expireDelegationToken(byte[] hmac) {
         return expireDelegationToken(hmac, new ExpireDelegationTokenOptions());

--- a/examples/consumer/src/main/java/org/oracle/okafka/examples/Consumer.java
+++ b/examples/consumer/src/main/java/org/oracle/okafka/examples/Consumer.java
@@ -107,7 +107,7 @@ public class Consumer {
 
         try {
             Properties prop = new Properties();
-            String propFileName = "config.properties_local";
+            String propFileName = "config.properties";
 
             inputStream = Consumer.class.getClassLoader().getResourceAsStream(propFileName);
             if (inputStream != null) {

--- a/examples/producer/src/main/java/org/oracle/okafka/examples/Producer.java
+++ b/examples/producer/src/main/java/org/oracle/okafka/examples/Producer.java
@@ -99,7 +99,7 @@ public class Producer {
 
 		try {
 			Properties prop = new Properties();
-			String propFileName = "config.properties_local";
+			String propFileName = "config.properties";
 
 			inputStream = Producer.class.getClassLoader().getResourceAsStream(propFileName);
 			if (inputStream != null) {


### PR DESCRIPTION
This PR addresses issues #1 and #11 and some typos for the Javadoc generation.

 Changes to be committed:
 > Updated repo documentation.
	modified:   README.md

> fix typos
	modified:   clients/src/main/java/org/oracle/okafka/clients/admin/AdminClient.java

> Fix properties file name
	modified:   examples/consumer/src/main/java/org/oracle/okafka/examples/Consumer.java
	modified:   examples/producer/src/main/java/org/oracle/okafka/examples/Producer.java