### PR TITLE
Added listOffsets() Feature in KafkaAdminClient and fixed two bugs.

### DIFF
--- a/clients/src/main/java/org/oracle/okafka/clients/admin/AdminClientConfig.java
+++ b/clients/src/main/java/org/oracle/okafka/clients/admin/AdminClientConfig.java
@@ -76,6 +76,12 @@ public class AdminClientConfig extends AbstractConfig {
     private static final String RETRY_BACKOFF_MS_DOC = "The amount of time to wait before attempting to " +
                 "retry a failed request. This avoids repeatedly sending requests in a tight loop under " +
                 "some failure scenarios.";
+    
+    /**
+     * <code>retry.backoff.max.ms</code>
+     */
+    public static final String RETRY_BACKOFF_MAX_MS_CONFIG = CommonClientConfigs.RETRY_BACKOFF_MAX_MS_CONFIG;
+    private static final String RETRY_BACKOFF_MAX_MS_DOC = CommonClientConfigs.RETRY_BACKOFF_MAX_MS_DOC;
 
     /** <code>connections.max.idle.ms</code> */
     public static final String CONNECTIONS_MAX_IDLE_MS_CONFIG = CommonClientConfigs.CONNECTIONS_MAX_IDLE_MS_CONFIG;
@@ -142,6 +148,12 @@ public class AdminClientConfig extends AbstractConfig {
                                         atLeast(0L),
                                         Importance.LOW,
                                         RETRY_BACKOFF_MS_DOC)
+                                .define(RETRY_BACKOFF_MAX_MS_CONFIG,
+                                        Type.LONG,
+                                        1000L,
+                                        atLeast(0L),
+                                        Importance.LOW,
+                                        RETRY_BACKOFF_MAX_MS_DOC)
                                 .define(REQUEST_TIMEOUT_MS_CONFIG,
                                         Type.INT,
                                         120000,

--- a/clients/src/main/java/org/oracle/okafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/oracle/okafka/clients/admin/KafkaAdminClient.java
@@ -2207,7 +2207,7 @@ public class KafkaAdminClient extends AdminClient {
 		}
 						
 		final long now = time.milliseconds();
-
+		
 		runnable.call(
 				new Call("listOffsets", calcDeadlineMs(now, options.timeoutMs()), new LeastLoadedNodeProvider()) {
 

--- a/clients/src/main/java/org/oracle/okafka/common/network/AQClient.java
+++ b/clients/src/main/java/org/oracle/okafka/common/network/AQClient.java
@@ -644,6 +644,7 @@ public abstract class AQClient {
 			List<PartitionInfo> partitionInfo, Map<String, Exception> errorsPerTopic, Map<String,Uuid> topicNameIdMap) throws Exception {
 		if(nodes.size() <= 0 || topics == null || topics.isEmpty())
 			return;
+		
 		String queryQShard[] = {"select SHARD_ID, OWNER_INSTANCE, QUEUE_ID from user_queue_shards where  QUEUE_ID = (select qid from user_queues where name = upper(?)) ",
 		"select SHARD_ID, ENQUEUE_INSTANCE, QUEUE_ID from user_queue_shards where  QUEUE_ID = (select qid from user_queues where name = upper(?)) "};
 		

--- a/clients/src/main/java/org/oracle/okafka/common/protocol/ApiKeys.java
+++ b/clients/src/main/java/org/oracle/okafka/common/protocol/ApiKeys.java
@@ -32,6 +32,8 @@
 package 
 org.oracle.okafka.common.protocol;
 
+import org.apache.kafka.common.message.ApiMessageType;
+
 /**
  * Identifiers for all the Kafka APIs
  */
@@ -47,7 +49,8 @@ public enum ApiKeys {
 	UNSUBSCRIBE(8, "Unsubscribe"),
 	JOIN_GROUP(9, "JoinGroup"),
 	SYNC_GROUP(10, "SyncGroup"),
-	CONNECT_ME(11,"ConnectMe");
+	CONNECT_ME(11,"ConnectMe"),
+	LIST_OFFSETS(12,"ListOffsets");
     private static final ApiKeys[] ID_TO_TYPE;
     private static final int MIN_API_KEY = 0;
     public static final int MAX_API_KEY;
@@ -143,6 +146,8 @@ public enum ApiKeys {
     	case CONNECT_ME:
     		//Operation to find Oracle RAC Node to connect to. Not exactly a FIND_CORRDINATOR call.
     		return org.apache.kafka.common.protocol.ApiKeys.FIND_COORDINATOR;
+    	case LIST_OFFSETS:
+    		return org.apache.kafka.common.protocol.ApiKeys.LIST_OFFSETS;
     	default: 
     		// Default to HEARTBEAT. No SUpport for HEARTBEAT for oKafka.
     		return org.apache.kafka.common.protocol.ApiKeys.HEARTBEAT;
@@ -180,6 +185,8 @@ public enum ApiKeys {
     	case FIND_COORDINATOR:
     		//Operation to find Oracle RAC Node to connect to. Not exactly a FIND_CORRDINATOR call.
     		return CONNECT_ME;
+    	case LIST_OFFSETS:
+    		return LIST_OFFSETS;
     	default: 
     		// Default to FETCH.
     		return FETCH;

--- a/clients/src/main/java/org/oracle/okafka/common/requests/AbstractRequest.java
+++ b/clients/src/main/java/org/oracle/okafka/common/requests/AbstractRequest.java
@@ -52,6 +52,5 @@ public abstract class AbstractRequest extends org.apache.kafka.common.requests.A
             return apiKey;
         }
 
-        public abstract T build();
     }
 }

--- a/clients/src/main/java/org/oracle/okafka/common/requests/ListOffsetsRequest.java
+++ b/clients/src/main/java/org/oracle/okafka/common/requests/ListOffsetsRequest.java
@@ -1,0 +1,112 @@
+package org.oracle.okafka.common.requests;
+
+import java.util.List;
+import java.util.Map;
+
+import org.apache.kafka.common.protocol.ApiMessage;
+import org.apache.kafka.common.requests.AbstractResponse;
+import org.oracle.okafka.common.protocol.ApiKeys;
+
+public class ListOffsetsRequest extends AbstractRequest {
+	
+	public static final long EARLIEST_TIMESTAMP = -2L;
+    public static final long LATEST_TIMESTAMP = -1L;
+    public static final long MAX_TIMESTAMP = -3L;
+    
+    private final Map<String,List<ListOffsetsPartition>> topicoffsetPartitionMap;
+	
+	public static class Builder extends AbstractRequest.Builder<ListOffsetsRequest> {
+		private final Map<String,List<ListOffsetsPartition>> topicoffsetPartitionMap;
+		
+		public Builder (Map<String,List<ListOffsetsPartition>> topicoffsetPartitionMap) {
+			super(ApiKeys.LIST_OFFSETS);
+            this.topicoffsetPartitionMap=topicoffsetPartitionMap;
+        }
+		
+		@Override
+        public ListOffsetsRequest build(short version) {
+            return new ListOffsetsRequest(topicoffsetPartitionMap, version);
+        }
+
+        @Override
+        public String toString() {
+            return null;
+        }	
+	}
+	
+	private ListOffsetsRequest(Map<String,List<ListOffsetsPartition>> topicoffsetPartitionMap, short version) {
+        super(ApiKeys.LIST_OFFSETS, version);
+        this.topicoffsetPartitionMap=topicoffsetPartitionMap;
+    }
+	
+	public Map<String,List<ListOffsetsPartition>> getOffsetPartitionMap() {
+        return topicoffsetPartitionMap;
+    }
+
+	@Override
+	public ApiMessage data() {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public AbstractResponse getErrorResponse(int throttleTimeMs, Throwable e) {
+		// TODO Auto-generated method stub
+		return null;
+	}
+	
+	public static class ListOffsetsPartition {
+        int partitionIndex;
+        long timestamp;
+        
+        public ListOffsetsPartition() {
+            this.partitionIndex = 0;
+            this.timestamp = 0L;
+        }
+        
+        @Override
+        public boolean equals(Object obj) {
+            if (!(obj instanceof ListOffsetsPartition)) return false;
+            ListOffsetsPartition other = (ListOffsetsPartition) obj;
+            if (partitionIndex != other.partitionIndex) return false;
+            if (timestamp != other.timestamp) return false;
+            return true;
+        }
+        
+        @Override
+        public int hashCode() {
+            int hashCode = 0;
+            hashCode = 31 * hashCode + partitionIndex;
+            hashCode = 31 * hashCode + ((int) (timestamp >> 32) ^ (int) timestamp);
+            return hashCode;
+        }
+        
+        @Override
+        public String toString() {
+            return "ListOffsetsPartition("
+                + "partitionIndex=" + partitionIndex
+                + ", timestamp=" + timestamp
+                + ")";
+        }
+        
+        public int partitionIndex() {
+            return this.partitionIndex;
+        }
+        
+        public long timestamp() {
+            return this.timestamp;
+        }
+        
+        public ListOffsetsPartition setPartitionIndex(int v) {
+            this.partitionIndex = v;
+            return this;
+        }
+        
+        public ListOffsetsPartition setTimestamp(long v) {
+            this.timestamp = v;
+            return this;
+        }
+      
+	}
+
+}

--- a/clients/src/main/java/org/oracle/okafka/common/requests/ListOffsetsRequest.java
+++ b/clients/src/main/java/org/oracle/okafka/common/requests/ListOffsetsRequest.java
@@ -5,43 +5,44 @@ import java.util.Map;
 
 import org.apache.kafka.common.protocol.ApiMessage;
 import org.apache.kafka.common.requests.AbstractResponse;
+import org.apache.kafka.common.utils.Utils;
 import org.oracle.okafka.common.protocol.ApiKeys;
 
 public class ListOffsetsRequest extends AbstractRequest {
-	
-	public static final long EARLIEST_TIMESTAMP = -2L;
-    public static final long LATEST_TIMESTAMP = -1L;
-    public static final long MAX_TIMESTAMP = -3L;
-    
-    private final Map<String,List<ListOffsetsPartition>> topicoffsetPartitionMap;
-	
-	public static class Builder extends AbstractRequest.Builder<ListOffsetsRequest> {
-		private final Map<String,List<ListOffsetsPartition>> topicoffsetPartitionMap;
-		
-		public Builder (Map<String,List<ListOffsetsPartition>> topicoffsetPartitionMap) {
-			super(ApiKeys.LIST_OFFSETS);
-            this.topicoffsetPartitionMap=topicoffsetPartitionMap;
-        }
-		
-		@Override
-        public ListOffsetsRequest build(short version) {
-            return new ListOffsetsRequest(topicoffsetPartitionMap, version);
-        }
 
-        @Override
-        public String toString() {
-            return null;
-        }	
+	public static final long EARLIEST_TIMESTAMP = -2L;
+	public static final long LATEST_TIMESTAMP = -1L;
+	public static final long MAX_TIMESTAMP = -3L;
+
+	private final Map<String, List<ListOffsetsPartition>> topicoffsetPartitionMap;
+
+	public static class Builder extends AbstractRequest.Builder<ListOffsetsRequest> {
+		private final Map<String, List<ListOffsetsPartition>> topicoffsetPartitionMap;
+
+		public Builder(Map<String, List<ListOffsetsPartition>> topicoffsetPartitionMap) {
+			super(ApiKeys.LIST_OFFSETS);
+			this.topicoffsetPartitionMap = topicoffsetPartitionMap;
+		}
+
+		@Override
+		public ListOffsetsRequest build(short version) {
+			return new ListOffsetsRequest(topicoffsetPartitionMap, version);
+		}
+
+		@Override
+		public String toString() {
+			return "(type=ListOffsetsRequest, " + topicoffsetPartitionMap.toString();
+		}
 	}
-	
-	private ListOffsetsRequest(Map<String,List<ListOffsetsPartition>> topicoffsetPartitionMap, short version) {
-        super(ApiKeys.LIST_OFFSETS, version);
-        this.topicoffsetPartitionMap=topicoffsetPartitionMap;
-    }
-	
-	public Map<String,List<ListOffsetsPartition>> getOffsetPartitionMap() {
-        return topicoffsetPartitionMap;
-    }
+
+	private ListOffsetsRequest(Map<String, List<ListOffsetsPartition>> topicoffsetPartitionMap, short version) {
+		super(ApiKeys.LIST_OFFSETS, version);
+		this.topicoffsetPartitionMap = topicoffsetPartitionMap;
+	}
+
+	public Map<String, List<ListOffsetsPartition>> getOffsetPartitionMap() {
+		return topicoffsetPartitionMap;
+	}
 
 	@Override
 	public ApiMessage data() {
@@ -54,59 +55,59 @@ public class ListOffsetsRequest extends AbstractRequest {
 		// TODO Auto-generated method stub
 		return null;
 	}
-	
+
 	public static class ListOffsetsPartition {
-        int partitionIndex;
-        long timestamp;
-        
-        public ListOffsetsPartition() {
-            this.partitionIndex = 0;
-            this.timestamp = 0L;
-        }
-        
-        @Override
-        public boolean equals(Object obj) {
-            if (!(obj instanceof ListOffsetsPartition)) return false;
-            ListOffsetsPartition other = (ListOffsetsPartition) obj;
-            if (partitionIndex != other.partitionIndex) return false;
-            if (timestamp != other.timestamp) return false;
-            return true;
-        }
-        
-        @Override
-        public int hashCode() {
-            int hashCode = 0;
-            hashCode = 31 * hashCode + partitionIndex;
-            hashCode = 31 * hashCode + ((int) (timestamp >> 32) ^ (int) timestamp);
-            return hashCode;
-        }
-        
-        @Override
-        public String toString() {
-            return "ListOffsetsPartition("
-                + "partitionIndex=" + partitionIndex
-                + ", timestamp=" + timestamp
-                + ")";
-        }
-        
-        public int partitionIndex() {
-            return this.partitionIndex;
-        }
-        
-        public long timestamp() {
-            return this.timestamp;
-        }
-        
-        public ListOffsetsPartition setPartitionIndex(int v) {
-            this.partitionIndex = v;
-            return this;
-        }
-        
-        public ListOffsetsPartition setTimestamp(long v) {
-            this.timestamp = v;
-            return this;
-        }
-      
+		int partitionIndex;
+		long timestamp;
+
+		public ListOffsetsPartition() {
+			this.partitionIndex = 0;
+			this.timestamp = 0L;
+		}
+
+		@Override
+		public boolean equals(Object obj) {
+			if (!(obj instanceof ListOffsetsPartition))
+				return false;
+			ListOffsetsPartition other = (ListOffsetsPartition) obj;
+			if (partitionIndex != other.partitionIndex)
+				return false;
+			if (timestamp != other.timestamp)
+				return false;
+			return true;
+		}
+
+		@Override
+		public int hashCode() {
+			int hashCode = 0;
+			hashCode = 31 * hashCode + partitionIndex;
+			hashCode = 31 * hashCode + ((int) (timestamp >> 32) ^ (int) timestamp);
+			return hashCode;
+		}
+
+		@Override
+		public String toString() {
+			return "ListOffsetsPartition(" + "partitionIndex=" + partitionIndex + ", timestamp=" + timestamp + ")";
+		}
+
+		public int partitionIndex() {
+			return this.partitionIndex;
+		}
+
+		public long timestamp() {
+			return this.timestamp;
+		}
+
+		public ListOffsetsPartition setPartitionIndex(int v) {
+			this.partitionIndex = v;
+			return this;
+		}
+
+		public ListOffsetsPartition setTimestamp(long v) {
+			this.timestamp = v;
+			return this;
+		}
+
 	}
 
 }

--- a/clients/src/main/java/org/oracle/okafka/common/requests/ListOffsetsResponse.java
+++ b/clients/src/main/java/org/oracle/okafka/common/requests/ListOffsetsResponse.java
@@ -1,0 +1,139 @@
+package org.oracle.okafka.common.requests;
+
+import java.util.List;
+import java.util.Map;
+
+import org.apache.kafka.common.protocol.ApiMessage;
+import org.apache.kafka.common.protocol.Errors;
+import org.oracle.okafka.common.errors.FeatureNotSupportedException;
+import org.oracle.okafka.common.protocol.ApiKeys;
+
+public class ListOffsetsResponse extends AbstractResponse {
+	final Map<String, List<ListOffsetsPartitionResponse>> offsetPartitionResponseMap;
+	private Exception exception;
+
+	public ListOffsetsResponse(Map<String, List<ListOffsetsPartitionResponse>> offsetPartitionResponseMap) {
+		super(ApiKeys.LIST_OFFSETS);
+		this.offsetPartitionResponseMap = offsetPartitionResponseMap;
+		exception = null;
+	}
+
+	public Map<String, List<ListOffsetsPartitionResponse>> getOffsetPartitionResponseMap() {
+		return offsetPartitionResponseMap;
+	}
+
+	public void setException(Exception ex) {
+		if (exception != null) {
+			exception = ex;
+		}
+	}
+
+	public Exception getException() {
+		return exception;
+	}
+
+	public static class ListOffsetsPartitionResponse {
+		int partitionIndex;
+		Exception error;
+		long timestamp;
+		long offset;
+		
+		public ListOffsetsPartitionResponse() {
+            this.partitionIndex = 0;
+            this.error = null;
+            this.timestamp = -1L;
+            this.offset = -1L;
+        }
+
+		@Override
+		public boolean equals(Object obj) {
+			if (!(obj instanceof ListOffsetsPartitionResponse))
+				return false;
+			ListOffsetsPartitionResponse other = (ListOffsetsPartitionResponse) obj;
+			if (partitionIndex != other.partitionIndex)
+				return false;
+			if (error != other.error)
+				return false;
+			if (timestamp != other.timestamp)
+				return false;
+			if (offset != other.offset)
+				return false;
+			return true;
+		}
+
+		@Override
+		public int hashCode() {
+			int hashCode = 0;
+			hashCode = 31 * hashCode + partitionIndex;
+			hashCode = 31 * hashCode + ((int) (timestamp >> 32) ^ (int) timestamp);
+			hashCode = 31 * hashCode + ((int) (offset >> 32) ^ (int) offset);
+			return hashCode;
+		}
+
+		@Override
+		public String toString() {
+			return "ListOffsetsPartitionResponse(" + "partitionIndex=" + partitionIndex + ", error=" + error
+					+ ", timestamp=" + timestamp + ", offset=" + offset + ")";
+		}
+
+		public int partitionIndex() {
+			return this.partitionIndex;
+		}
+
+		public Exception getError() {
+			return this.error;
+		}
+
+		public long timestamp() {
+			return this.timestamp;
+		}
+
+		public long offset() {
+			return this.offset;
+		}
+
+		public ListOffsetsPartitionResponse setPartitionIndex(int v) {
+			this.partitionIndex = v;
+			return this;
+		}
+
+		public ListOffsetsPartitionResponse setError(Exception v) {
+			this.error = v;
+			return this;
+		}
+
+		public ListOffsetsPartitionResponse setTimestamp(long v) {
+			this.timestamp = v;
+			return this;
+		}
+
+		public ListOffsetsPartitionResponse setOffset(long v) {
+			this.offset = v;
+			return this;
+		}
+	}
+
+	@Override
+	public ApiMessage data() {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public Map<Errors, Integer> errorCounts() {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public int throttleTimeMs() {
+		// TODO Auto-generated method stub
+		return 0;
+	}
+
+	@Override
+	public void maybeSetThrottleTimeMs(int throttleTimeMs) {
+		throw new FeatureNotSupportedException("This feature is not suported for this release.");
+	}
+
+}

--- a/clients/src/main/java/org/oracle/okafka/common/requests/MetadataRequest.java
+++ b/clients/src/main/java/org/oracle/okafka/common/requests/MetadataRequest.java
@@ -69,10 +69,10 @@ public class MetadataRequest extends AbstractRequest {
 
 		public Builder(List<Uuid> topicIds) {
 			super(ApiKeys.METADATA);
-			this.topicIds = topicIds;
-			this.topics = null;
-			this.allowAutoTopicCreation = false;
-			this.teqParaTopic = null;
+			this.topicIds=topicIds;
+			this.topics=null;
+			this.allowAutoTopicCreation=false;
+			this.teqParaTopic=null;
 		}
 
 		public static Builder allTopics() {

--- a/clients/src/main/java/org/oracle/okafka/common/utils/FetchOffsets.java
+++ b/clients/src/main/java/org/oracle/okafka/common/utils/FetchOffsets.java
@@ -157,7 +157,7 @@ public class FetchOffsets {
 			}
 
 			long offset = MessageIdConverter.getOKafkaOffset("ID:" + msgIdHex, true, true).getOffset();
-			response.setOffset(offset);
+			response.setOffset(offset+1);
 
 		} catch (SQLException sqle) {
 			if (sqle.getErrorCode() == 20001) {

--- a/clients/src/main/java/org/oracle/okafka/common/utils/FetchOffsets.java
+++ b/clients/src/main/java/org/oracle/okafka/common/utils/FetchOffsets.java
@@ -1,0 +1,380 @@
+package org.oracle.okafka.common.utils;
+
+import java.sql.CallableStatement;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.sql.Types;
+
+import org.oracle.okafka.common.requests.ListOffsetsResponse.ListOffsetsPartitionResponse;
+
+public class FetchOffsets {
+
+	public static ListOffsetsPartitionResponse fetchEarliestOffset(String topic, int partition, Connection jdbcConn)
+			throws SQLException {
+		ListOffsetsPartitionResponse response = new ListOffsetsPartitionResponse().setPartitionIndex(partition);
+		CallableStatement cStmt = null;
+		String plsql = """
+				DECLARE
+				    shard_num NUMBER := ?;
+				    queue_name VARCHAR2(128) := ?;
+				    partition_name VARCHAR2(50);
+				    msg_id RAW(16);
+				    total_shards NUMBER;
+				BEGIN
+					EXECUTE IMMEDIATE 'SELECT COUNT(DISTINCT(SHARD)) FROM ' || DBMS_ASSERT.SQL_OBJECT_NAME(queue_name)
+				    INTO total_shards;
+
+				   	IF shard_num>=total_shards THEN
+				   	   	RAISE_APPLICATION_ERROR(20001, 'Invalid partition number');
+				   	END IF;
+				BEGIN
+				    SELECT LOWER(PARTNAME) INTO partition_name
+				    FROM USER_QUEUE_PARTITION_MAP
+				    WHERE QUEUE_TABLE = queue_name AND SHARD = shard_num AND SUBSHARD = (
+				        SELECT MIN(SUBSHARD)
+				        FROM USER_QUEUE_PARTITION_MAP
+				        WHERE QUEUE_TABLE = queue_name AND SHARD = shard_num
+				    );
+
+				    EXECUTE IMMEDIATE
+				        'SELECT MIN(MSGID) FROM ' || DBMS_ASSERT.SQL_OBJECT_NAME(queue_name) || ' PARTITION (' || partition_name || ')'
+				         INTO msg_id;
+
+				        ? := msg_id;
+
+				    EXCEPTION
+				    WHEN NO_DATA_FOUND THEN
+				    	RAISE_APPLICATION_ERROR(20003, 'No messages in the given partition');
+				END;
+				   	EXCEPTION
+				   	WHEN NO_DATA_FOUND THEN
+				   		RAISE_APPLICATION_ERROR(20002, 'Invalid queue name');
+				   	WHEN OTHERS THEN
+				   		RAISE;
+
+				END;
+				""";
+		try {
+			cStmt = jdbcConn.prepareCall(plsql);
+			cStmt.setInt(1, partition * 2);
+			cStmt.setString(2, topic);
+
+			cStmt.registerOutParameter(3, Types.BINARY);
+
+			cStmt.executeQuery();
+
+			byte[] msgIdBytes = cStmt.getBytes(3);
+
+			StringBuilder msgIdHex = new StringBuilder();
+			for (byte b : msgIdBytes) {
+				msgIdHex.append(String.format("%02X", b));
+			}
+
+			long offset = MessageIdConverter.getOKafkaOffset("ID:" + msgIdHex, true, true).getOffset();
+			response.setOffset(offset);
+
+		} catch (SQLException sqle) {
+			if (sqle.getErrorCode() == 20001) {
+				response.setError(new IllegalArgumentException("Partition Number Is Invalid"));
+			} else if (sqle.getErrorCode() == 20002) {
+				response.setError(new IllegalArgumentException("Queue with the provided name doesn't exist"));
+			} else if (sqle.getErrorCode() == 20003) {
+				response.setOffset(0);
+			} else
+				throw sqle;
+		} finally {
+			try {
+				if (cStmt != null)
+					cStmt.close();
+			} catch (Exception ex) {
+				// do nothing
+			}
+		}
+		return response;
+	}
+
+	public static ListOffsetsPartitionResponse fetchLatestOffset(String topic, int partition, Connection jdbcConn)
+			throws SQLException {
+
+		ListOffsetsPartitionResponse response = new ListOffsetsPartitionResponse().setPartitionIndex(partition);
+		CallableStatement cStmt = null;
+		String plsql = """
+				DECLARE
+				    shard_num NUMBER := ?;
+				    queue_name VARCHAR2(128) := ?;
+				    partition_name VARCHAR2(50);
+				    msg_id RAW(16);
+				    total_shards NUMBER;
+				BEGIN
+					EXECUTE IMMEDIATE 'SELECT COUNT(DISTINCT(SHARD)) FROM ' || DBMS_ASSERT.SQL_OBJECT_NAME(queue_name)
+				    INTO total_shards;
+
+				   	IF shard_num>=total_shards THEN
+				   	   	RAISE_APPLICATION_ERROR(20001, 'Invalid partition number');
+				   	END IF;
+				BEGIN
+				    SELECT LOWER(PARTNAME) INTO partition_name
+				    FROM USER_QUEUE_PARTITION_MAP
+				    WHERE QUEUE_TABLE = queue_name AND SHARD = shard_num AND SUBSHARD = (
+				        SELECT MAX(SUBSHARD)
+				        FROM USER_QUEUE_PARTITION_MAP
+				        WHERE QUEUE_TABLE = queue_name AND SHARD = shard_num
+				    );
+
+				    EXECUTE IMMEDIATE
+				        'SELECT MAX(MSGID) FROM ' || DBMS_ASSERT.SQL_OBJECT_NAME(queue_name) || ' PARTITION (' || partition_name || ')'
+				         INTO msg_id;
+
+				        ? := msg_id;
+
+				    EXCEPTION
+				    WHEN NO_DATA_FOUND THEN
+				    	RAISE_APPLICATION_ERROR(20003, 'No messages in the given partition');
+				END;
+				   	EXCEPTION
+				   	WHEN NO_DATA_FOUND THEN
+				   		RAISE_APPLICATION_ERROR(20002, 'Invalid queue name');
+				   	WHEN OTHERS THEN
+				   		RAISE;
+
+				END;
+				""";
+		try {
+			cStmt = jdbcConn.prepareCall(plsql);
+			cStmt.setInt(1, partition * 2);
+			cStmt.setString(2, topic);
+
+			cStmt.registerOutParameter(3, Types.BINARY);
+
+			cStmt.executeQuery();
+
+			byte[] msgIdBytes = cStmt.getBytes(3);
+
+			StringBuilder msgIdHex = new StringBuilder();
+			for (byte b : msgIdBytes) {
+				msgIdHex.append(String.format("%02X", b));
+			}
+
+			long offset = MessageIdConverter.getOKafkaOffset("ID:" + msgIdHex, true, true).getOffset();
+			response.setOffset(offset);
+
+		} catch (SQLException sqle) {
+			if (sqle.getErrorCode() == 20001) {
+				response.setError(new IllegalArgumentException("Partition Number Is Invalid"));
+			} else if (sqle.getErrorCode() == 20002) {
+				response.setError(new IllegalArgumentException("Queue with the provided name doesn't exist"));
+			} else if (sqle.getErrorCode() == 20003) {
+				response.setOffset(0);
+			} else
+				throw sqle;
+		} finally {
+			try {
+				if (cStmt != null)
+					cStmt.close();
+			} catch (Exception ex) {
+				// do nothing
+			}
+		}
+		return response;
+
+	}
+
+	public static ListOffsetsPartitionResponse fetchOffsetByTimestamp(String topic, int partition, long timestamp,
+			Connection jdbcConn) throws SQLException {
+
+		ListOffsetsPartitionResponse response = new ListOffsetsPartitionResponse().setPartitionIndex(partition);
+		CallableStatement cStmt = null;
+		String plsql = """
+				DECLARE
+				    shard_num NUMBER := ?;
+				    queue_name VARCHAR2(128) := ?;
+				    user_timestamp TIMESTAMP(6) WITH TIME ZONE := TO_TIMESTAMP_TZ(?, 'DD-MON-YY HH.MI.SSXFF AM TZR');
+				    partition_list SYS.ODCIVARCHAR2LIST := SYS.ODCIVARCHAR2LIST();
+				    next_timestamp TIMESTAMP(6) WITH TIME ZONE;
+				    msg_id RAW(16);
+				    found BOOLEAN := FALSE;
+				    total_shards NUMBER;
+				BEGIN
+				EXECUTE IMMEDIATE 'SELECT COUNT(DISTINCT(SHARD)) FROM ' || DBMS_ASSERT.SQL_OBJECT_NAME(queue_name)
+				    INTO total_shards;
+
+				   	IF shard_num>=total_shards THEN
+				   	   	RAISE_APPLICATION_ERROR(20001, 'Invalid partition number');
+				   	END IF;
+				BEGIN
+				    SELECT LOWER(PARTNAME)
+				    BULK COLLECT INTO partition_list
+				    FROM USER_QUEUE_PARTITION_MAP
+				    WHERE QUEUE_TABLE = queue_name AND SHARD = shard_num;
+
+				    FOR i IN 1..partition_list.COUNT LOOP
+				        BEGIN
+				            EXECUTE IMMEDIATE
+				                'SELECT MSGID, ENQUEUE_TIME
+				                 FROM ' || DBMS_ASSERT.SQL_OBJECT_NAME(queue_name) || ' PARTITION (' || partition_list(i) || ')
+				                 WHERE ENQUEUE_TIME >= :1
+				                 ORDER BY ENQUEUE_TIME FETCH FIRST 1 ROW ONLY'
+				                INTO msg_id, next_timestamp
+				                USING user_timestamp;
+
+				            found := TRUE;
+				            EXIT;
+				        EXCEPTION
+				            WHEN NO_DATA_FOUND THEN
+				                NULL;
+				        END;
+				    END LOOP;
+
+				    IF NOT found THEN
+				        RAISE_APPLICATION_ERROR(20003, 'No messages in the given partition');
+				    END IF;
+
+				    ? := msg_id;
+				    ? := next_timestamp;
+				END;
+				EXCEPTION
+				   	WHEN NO_DATA_FOUND THEN
+				   		RAISE_APPLICATION_ERROR(20002, 'Invalid queue name');
+				   	WHEN OTHERS THEN
+				   		RAISE;
+				END;
+				""";
+		try {
+			cStmt = jdbcConn.prepareCall(plsql);
+			cStmt.setInt(1, partition * 2);
+			cStmt.setString(2, topic);
+			cStmt.setString(3, TimestampConverter.timestampInUTCTimeZone(timestamp));
+
+			cStmt.registerOutParameter(4, Types.BINARY);
+			cStmt.registerOutParameter(5, Types.TIMESTAMP_WITH_TIMEZONE);
+
+			cStmt.executeQuery();
+
+			byte[] msgIdBytes = cStmt.getBytes(4);
+			Timestamp enqueueTimestamp = cStmt.getTimestamp(5);
+
+			StringBuilder msgIdHex = new StringBuilder();
+			for (byte b : msgIdBytes) {
+				msgIdHex.append(String.format("%02X", b));
+			}
+
+			long offset = MessageIdConverter.getOKafkaOffset("ID:" + msgIdHex, true, true).getOffset();
+			long okafkaTimestamp = enqueueTimestamp.toInstant().toEpochMilli();
+
+			response.setOffset(offset).setTimestamp(okafkaTimestamp);
+
+		} catch (SQLException sqle) {
+			if (sqle.getErrorCode() == 20001) {
+				response.setError(new IllegalArgumentException("Partition Number Is Invalid"));
+			} else if (sqle.getErrorCode() == 20002) {
+				response.setError(new IllegalArgumentException("Queue with the provided name doesn't exist"));
+			} else if (sqle.getErrorCode() == 20003) {
+				// do nothing;
+			} else
+				throw sqle;
+		} finally {
+			try {
+				if (cStmt != null)
+					cStmt.close();
+			} catch (Exception ex) {
+				// do nothing
+			}
+		}
+		return response;
+	}
+
+	public static ListOffsetsPartitionResponse fetchMaxTimestampOffset(String topic, int partition, Connection jdbcConn)
+			throws SQLException {
+
+		ListOffsetsPartitionResponse response = new ListOffsetsPartitionResponse().setPartitionIndex(partition);
+		CallableStatement cStmt = null;
+		String plsql = """
+				DECLARE
+				    shard_num NUMBER := ?;
+				    queue_name VARCHAR2(128) := ?;
+				    partition_name VARCHAR2(50);
+				    msg_id RAW(16);
+				    enqueue_time TIMESTAMP(6) WITH TIME ZONE;
+				    total_shards NUMBER;
+				BEGIN
+					EXECUTE IMMEDIATE 'SELECT COUNT(DISTINCT(SHARD)) FROM ' || DBMS_ASSERT.SQL_OBJECT_NAME(queue_name)
+				    INTO total_shards;
+
+				   	IF shard_num>=total_shards THEN
+				   	   	RAISE_APPLICATION_ERROR(20001, 'Invalid partition number');
+				   	END IF;
+				BEGIN
+				    SELECT LOWER(PARTNAME) INTO partition_name
+				    FROM USER_QUEUE_PARTITION_MAP
+				    WHERE QUEUE_TABLE = queue_name AND SHARD = shard_num AND SUBSHARD = (
+				        SELECT MAX(SUBSHARD)
+				        FROM USER_QUEUE_PARTITION_MAP
+				        WHERE QUEUE_TABLE = queue_name AND SHARD = shard_num
+				    );
+
+				    EXECUTE IMMEDIATE
+				        'SELECT MSGID, ENQUEUE_TIME
+				         FROM ' || DBMS_ASSERT.SQL_OBJECT_NAME(queue_name) || ' PARTITION (' || partition_name || ')
+				         WHERE MSGID = (SELECT MAX(MSGID) FROM ' || DBMS_ASSERT.SQL_OBJECT_NAME(queue_name) || ' PARTITION (' || partition_name || '))'
+				        INTO msg_id, enqueue_time;
+
+				        ? := msg_id;
+				        ? := enqueue_time;
+
+				    EXCEPTION
+				    WHEN NO_DATA_FOUND THEN
+				    	RAISE_APPLICATION_ERROR(20003, 'No messages in the given partition');
+				END;
+				   	EXCEPTION
+				   	WHEN NO_DATA_FOUND THEN
+				   		RAISE_APPLICATION_ERROR(20002, 'Invalid queue name');
+				   	WHEN OTHERS THEN
+				   		RAISE;
+
+				END;
+				""";
+		try {
+			cStmt = jdbcConn.prepareCall(plsql);
+			cStmt.setInt(1, partition * 2);
+			cStmt.setString(2, topic);
+
+			cStmt.registerOutParameter(3, Types.BINARY);
+			cStmt.registerOutParameter(4, Types.TIMESTAMP_WITH_TIMEZONE);
+
+			cStmt.executeQuery();
+
+			byte[] msgIdBytes = cStmt.getBytes(3);
+			Timestamp enqueueTimestamp = cStmt.getTimestamp(4);
+
+			StringBuilder msgIdHex = new StringBuilder();
+			for (byte b : msgIdBytes) {
+				msgIdHex.append(String.format("%02X", b));
+			}
+
+			long offset = MessageIdConverter.getOKafkaOffset("ID:" + msgIdHex, true, true).getOffset();
+			long okafkaTimestamp = enqueueTimestamp.toInstant().toEpochMilli();
+
+			response.setOffset(offset).setTimestamp(okafkaTimestamp);
+
+		} catch (SQLException sqle) {
+			if (sqle.getErrorCode() == 20001) {
+				response.setError(new IllegalArgumentException("Partition Number Is Invalid"));
+			} else if (sqle.getErrorCode() == 20002) {
+				response.setError(new IllegalArgumentException("Queue with the provided name doesn't exist"));
+			} else if (sqle.getErrorCode() == 20003) {
+				// do nothing
+			} else
+				throw sqle;
+		} finally {
+			try {
+				if (cStmt != null)
+					cStmt.close();
+			} catch (Exception ex) {
+				// do nothing
+			}
+		}
+		return response;
+
+	}
+}

--- a/clients/src/main/java/org/oracle/okafka/common/utils/TimestampConverter.java
+++ b/clients/src/main/java/org/oracle/okafka/common/utils/TimestampConverter.java
@@ -1,0 +1,32 @@
+package org.oracle.okafka.common.utils;
+
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+
+public class TimestampConverter {
+	
+	public static final String UTC_ZONE_OFFSET = "+00:00"; 
+	
+	public static long timestampInEpochMillis(String okafkaTimestamp) {
+		
+		String formattedTimestamp = okafkaTimestamp.substring(0, 4).toUpperCase() + okafkaTimestamp.substring(4, 6).toLowerCase()
+				+ okafkaTimestamp.substring(6).toUpperCase();
+		DateTimeFormatter formatter = DateTimeFormatter.ofPattern("dd-MMM-yy hh.mm.ss.SSSSSS a XXX",
+				java.util.Locale.ENGLISH);
+		OffsetDateTime offsetDateTime = OffsetDateTime.parse(formattedTimestamp, formatter);
+		Instant instant = offsetDateTime.toInstant();
+		return instant.toEpochMilli();
+
+	}
+	
+	public static String timestampInUTCTimeZone(long kafkaTimestamp) {
+		Instant instant = Instant.ofEpochMilli(kafkaTimestamp);
+
+		DateTimeFormatter formatter = DateTimeFormatter
+				.ofPattern("dd-MMM-yy hh.mm.ss.SSSSSS a", java.util.Locale.ENGLISH).withZone(ZoneOffset.UTC);
+
+		return formatter.format(instant) + " " + UTC_ZONE_OFFSET;
+	}
+}

--- a/clients/src/test/java/org/oracle/okafka/tests/OkafkaListOffsets.java
+++ b/clients/src/test/java/org/oracle/okafka/tests/OkafkaListOffsets.java
@@ -1,0 +1,40 @@
+package org.oracle.okafka.tests;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.clients.admin.ListOffsetsResult;
+import org.apache.kafka.clients.admin.OffsetSpec;
+import org.apache.kafka.clients.admin.ListOffsetsResult.ListOffsetsResultInfo;
+import org.apache.kafka.common.TopicPartition;
+import org.junit.Test;
+import org.oracle.okafka.clients.admin.AdminClient;
+
+public class OkafkaListOffsets {
+	@Test
+	public void ListOffsetTest() {
+
+		try (Admin admin = AdminClient.create(OkafkaSetup.setup())) {
+			TopicPartition tp1= new TopicPartition("TEQ",0);
+			TopicPartition tp2= new TopicPartition("TEQ",1);
+			TopicPartition tp3= new TopicPartition("TEQ",2);
+			
+			Map<TopicPartition,OffsetSpec> topicOffsetSpecMap = new HashMap<>();
+			topicOffsetSpecMap.put(tp1, OffsetSpec.earliest());
+			topicOffsetSpecMap.put(tp2, OffsetSpec.latest());
+			topicOffsetSpecMap.put(tp3, OffsetSpec.maxTimestamp());
+			
+			ListOffsetsResult result = admin.listOffsets(topicOffsetSpecMap);
+			Map<TopicPartition, ListOffsetsResultInfo> offsetResultMap = result.all().get();
+			for(Map.Entry<TopicPartition, ListOffsetsResultInfo> entry : offsetResultMap.entrySet())
+				System.out.println("Topic - "+ entry.getKey().topic() + ", Partition - " + entry.getKey().partition()+ " ," +entry.getValue().toString());
+			
+			System.out.println("Auto Closing admin now");
+		} catch (Exception e) {
+			System.out.println("Exception while listing offsets " + e);
+			e.printStackTrace();
+		}
+		System.out.println("Test: OkafkaListOffsets completed");
+	}
+}

--- a/clients/src/test/java/org/oracle/okafka/tests/TestRunner.java
+++ b/clients/src/test/java/org/oracle/okafka/tests/TestRunner.java
@@ -9,11 +9,12 @@ class TestRunner {
 
 		Result result = new Result();
 
-		result = JUnitCore.runClasses(SimpleOkafkaAdmin.class, SimpleOkafkaProducer.class, OkafkaAutoOffsetReset.class,
-				SimpleOkafkaProducer.class, OkafkaSeekToEnd.class, OkafkaSeekToBeginning.class,
-				SimpleOkafkaProducer.class, OkafkaUnsubscribe.class, ProducerMetricsTest.class,
-				ConsumerMetricsTest.class, OkafkaDescribeTopics.class, OkafkaListTopics.class,
-				OkafkaDescribeTopicsById.class, OkafkaDeleteTopic.class, OkafkaDeleteTopicById.class);
+		result = JUnitCore.runClasses(SimpleOkafkaAdmin.class, SimpleOkafkaProducer.class, OkafkaListOffsets.class,
+				OkafkaAutoOffsetReset.class, SimpleOkafkaProducer.class, OkafkaSeekToEnd.class,
+				OkafkaSeekToBeginning.class, SimpleOkafkaProducer.class, OkafkaUnsubscribe.class,
+				ProducerMetricsTest.class, ConsumerMetricsTest.class, OkafkaDescribeTopics.class,
+				OkafkaListTopics.class, OkafkaDescribeTopicsById.class, OkafkaDeleteTopic.class,
+				OkafkaDeleteTopicById.class);
 
 		for (Failure failure : result.getFailures()) {
 			System.out.println("Test failure : " + failure.toString());


### PR DESCRIPTION
-> added the functionality for listing the offsets ( earliest, latest, max timestamp, at specific timestamp)
-> There was an issue of class cast  in NetworkClient ( Issue - casting of AdminMetadataUpdater to DefaultMetadataUpdater was there which could not be done due to which runtime error.
-> while fetching metadataResponse, there was a case where node.size=1 and the topics which do not exist were not even being created in the getPartitionInfo function in AQClient. 