### PR TITLE
Changes for Handling Wrong/Host/port/user/password

### DIFF
--- a/clients/src/main/java/org/oracle/okafka/clients/NetworkClient.java
+++ b/clients/src/main/java/org/oracle/okafka/clients/NetworkClient.java
@@ -50,9 +50,9 @@ import org.oracle.okafka.common.requests.MetadataRequest;
 import org.oracle.okafka.common.requests.MetadataResponse;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.Time;
-import org.junit.platform.commons.util.FunctionUtils;
 import org.slf4j.Logger;
 
+import java.net.ConnectException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -538,39 +538,46 @@ public class NetworkClient implements KafkaClient {
 			this.connectionStates.connecting(node, now);
 			Node copyNode = new Node(node);
 			aqClient.connect(node);
-			if(!node.equals(copyNode)) {
+			if (!node.equals(copyNode)) {
 				this.connectionStates.remove(copyNode);
 				this.connectionStates.connecting(node, now);
 			}
 			this.connectionStates.ready(node);
 			log.debug("Connection is established to node {}", node);
-		} catch(Exception e) { 
-			if(e instanceof JMSException) {
-				JMSException jmsExcp = (JMSException)e;
-				String jmsError = jmsExcp.getErrorCode();
-				log.error("Connection Error " +jmsExcp );
-				if(jmsError != null && (jmsError.equals("12514") || jmsError.equals("12541"))) {
-					throw new ConnectionException(e);
-				}
-				if(jmsError != null && jmsError.equals("1405")) {
-					log.error("create session privilege is not assigned", e.getMessage());
-					log.info("create session, execute on dbms_aqin, execute on dbms_aqadm privileges required for producer to work");
-				} 
+		} catch (Exception e) {
+			log.error("Failed to connect to node {} with error {}", node, e.getMessage());
 
+			if (e instanceof JMSException) { // from Producer or Consumer
+				JMSException jmsExcp = (JMSException) e;
+				String jmsError = jmsExcp.getErrorCode();
+				if (jmsError != null && (jmsError.equals("12514") || jmsError.equals("12541"))) {
+					throw new ConnectionException(new ConnectException(e.getMessage()));
+				}
+				if (jmsError != null && jmsError.equals("1405")) {
+					log.error("create session privilege is not assigned", e.getMessage());
+					log.info(
+							"create session, execute on dbms_aqin, execute on dbms_aqadm privileges required for producer to work");
+				}
 			}
+
+			if (e instanceof JMSSecurityException)
+				throw new InvalidLoginCredentialsException("Invalid login details provided:" + e.getMessage());
+
 			/* attempt failed, we'll try again after the backoff */
 			connectionStates.disconnected(node, now);
 			/* maybe the problem is our metadata, update it */
-			if(!(metadataUpdater instanceof AdminMetadataUpdater))
-				((DefaultMetadataUpdater)metadataUpdater).requestUpdate();
+			if (!(metadataUpdater instanceof AdminMetadataUpdater))
+				((DefaultMetadataUpdater) metadataUpdater).requestUpdate();
 			else
 				metadataManager.requestUpdate();
-			
+
+			if (e instanceof ConnectionException) // from Admin
+				throw (ConnectionException) e;
+			if (e instanceof InvalidLoginCredentialsException)
+				throw (InvalidLoginCredentialsException) e;
+
 			log.warn("Error connecting to node {}", node, e);
-			
-			if (e instanceof JMSSecurityException)
-				throw new InvalidLoginCredentialsException("Invalid login details provided:" + e.getMessage());
-			
+
 			return false;
 		}
 		return true;
@@ -732,31 +739,25 @@ public class NetworkClient implements KafkaClient {
 				log.debug("Cannot send Request. connect Now to node: " + node);
 				if (connectionStates.canConnect(node, now)) {
 					// we don't have a connection to this node right now, make one
-					//log.info(this.toString() + " Initialize connection to node {} for sending metadata request", node);
-					try {
-						if( !initiateConnect(node, now))
-							return reconnectBackoffMs;
-					} catch(InvalidLoginCredentialsException ilc) {
-						log.error("Failed to connect to node {} with error {}", node, ilc.getMessage());
-						this.metadata.failedUpdate(now, new AuthenticationException(ilc.getMessage()));
+					// log.info(this.toString() + " Initialize connection to node {} for sending
+					// metadata request", node);
+
+					if (!initiateConnect(node, now))
 						return reconnectBackoffMs;
-					}   
-				} else return reconnectBackoffMs;            
+				} else
+					return reconnectBackoffMs;
 			}
 			this.metadataFetchInProgress = true;
 			MetadataRequest.Builder metadataRequest;
 			if (metadata.needMetadataForAllTopics()) {
 				metadataRequest = MetadataRequest.Builder.allTopics();
-			}
-			else           	
-			{
+			} else {
 				List<String> topicList = new ArrayList<>(metadata.topics());
-				metadataRequest = new MetadataRequest.Builder(topicList,
-						metadata.allowAutoTopicCreation(), topicList);
+				metadataRequest = new MetadataRequest.Builder(topicList, metadata.allowAutoTopicCreation(), topicList);
 			}
 			log.debug("Sending metadata request {} to node {}", metadataRequest, node);
 			sendInternalMetadataRequest(metadataRequest, node, now);
-			return defaultRequestTimeoutMs; 
+			return defaultRequestTimeoutMs;
 		}
 
 		@Override

--- a/clients/src/main/java/org/oracle/okafka/clients/NetworkClient.java
+++ b/clients/src/main/java/org/oracle/okafka/clients/NetworkClient.java
@@ -50,6 +50,7 @@ import org.oracle.okafka.common.requests.MetadataRequest;
 import org.oracle.okafka.common.requests.MetadataResponse;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.Time;
+import org.junit.platform.commons.util.FunctionUtils;
 import org.slf4j.Logger;
 
 import java.util.ArrayList;
@@ -535,7 +536,12 @@ public class NetworkClient implements KafkaClient {
 		try {
 			log.info("Initiating connection to node {}", node);
 			this.connectionStates.connecting(node, now);
+			Node copyNode = new Node(node);
 			aqClient.connect(node);
+			if(!node.equals(copyNode)) {
+				this.connectionStates.remove(copyNode);
+				this.connectionStates.connecting(node, now);
+			}
 			this.connectionStates.ready(node);
 			log.debug("Connection is established to node {}", node);
 		} catch(Exception e) { 

--- a/clients/src/main/java/org/oracle/okafka/clients/NetworkClient.java
+++ b/clients/src/main/java/org/oracle/okafka/clients/NetworkClient.java
@@ -554,9 +554,10 @@ public class NetworkClient implements KafkaClient {
 					throw new ConnectionException(new ConnectException(e.getMessage()));
 				}
 				if (jmsError != null && jmsError.equals("1405")) {
-					log.error("create session privilege is not assigned", e.getMessage());
+					log.error("create session privilege is not granted", e.getMessage());
 					log.info(
-							"create session, execute on dbms_aqin, execute on dbms_aqadm privileges required for producer to work");
+							"Check Oracle Documentation for Kafka Java Client Interface for Oracle Transactional"
+							+ " Event Queues to get the complete list of privileges required for the database user.");
 				}
 			}
 

--- a/clients/src/main/java/org/oracle/okafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/oracle/okafka/clients/admin/KafkaAdminClient.java
@@ -171,6 +171,7 @@ import org.oracle.okafka.common.config.SslConfigs;
 import org.apache.kafka.common.errors.ApiException;
 import org.apache.kafka.common.errors.AuthenticationException;
 import org.apache.kafka.common.errors.DisconnectException;
+import org.oracle.okafka.common.errors.ConnectionException;
 import org.oracle.okafka.common.errors.FeatureNotSupportedException;
 import org.oracle.okafka.common.errors.InvalidLoginCredentialsException;
 import org.apache.kafka.common.errors.InvalidTopicException;
@@ -220,6 +221,7 @@ import org.slf4j.Logger;
 import static org.apache.kafka.common.utils.Utils.closeQuietly;
 
 import java.lang.reflect.Method;
+import java.net.ConnectException;
 import java.net.InetSocketAddress;
 import java.sql.SQLException;
 import java.time.Duration;
@@ -240,6 +242,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
+
+import javax.jms.JMSException;
 
 /**
  * The default implementation of {@link AdminClient}. An instance of this class
@@ -1048,6 +1052,14 @@ public class KafkaAdminClient extends AdminClient {
 					return false;
 				}
 			} catch (Throwable t) {
+				if(t instanceof InvalidLoginCredentialsException)
+					throw t;
+				if(t instanceof ConnectionException) {
+					Throwable e = t.getCause();
+					if(e instanceof ConnectException) {
+						throw t;
+					}
+				}
 				// Handle authentication errors while choosing nodes.
 				log.debug("Unable to choose node for {}", call, t);
 				call.fail(now, t);

--- a/clients/src/main/java/org/oracle/okafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/oracle/okafka/clients/admin/KafkaAdminClient.java
@@ -243,8 +243,6 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
-import javax.jms.JMSException;
-
 /**
  * The default implementation of {@link AdminClient}. An instance of this class
  * is created by invoking one of the {@code create()} methods in

--- a/clients/src/main/java/org/oracle/okafka/clients/admin/internals/AQKafkaAdmin.java
+++ b/clients/src/main/java/org/oracle/okafka/clients/admin/internals/AQKafkaAdmin.java
@@ -7,6 +7,7 @@
 
 package org.oracle.okafka.clients.admin.internals;
 
+import java.net.ConnectException;
 import java.sql.CallableStatement;
 import java.sql.Connection;
 import java.sql.ResultSet;
@@ -621,10 +622,13 @@ public class AQKafkaAdmin extends AQClient{
 			this.metadataManager.update(newCluster, System.currentTimeMillis());
 		} catch (SQLException excp) {
 			log.error("Exception while connecting to Oracle Database " + excp, excp);
-			if (excp.getErrorCode() == 1017)
+			int errorCode = excp.getErrorCode();
+			if (errorCode == 1017)
 				throw new InvalidLoginCredentialsException(excp);
-
-			throw new ConnectionException(excp.getMessage());
+			if(errorCode==12514 || errorCode==12541)
+				throw new ConnectionException(new ConnectException(excp.getMessage()));
+			
+			throw new ConnectionException(excp);
 		}
 		return connections.get(node);
 	}

--- a/clients/src/main/java/org/oracle/okafka/clients/consumer/KafkaConsumer.java
+++ b/clients/src/main/java/org/oracle/okafka/clients/consumer/KafkaConsumer.java
@@ -29,7 +29,6 @@
 
 package org.oracle.okafka.clients.consumer;
 
-import java.net.ConnectException;
 import java.net.InetSocketAddress;
 import java.nio.ByteBuffer;
 import java.sql.Connection;
@@ -47,13 +46,11 @@ import java.util.Optional;
 import java.util.OptionalLong;
 import java.util.Properties;
 import java.util.Set;
-import java.util.StringTokenizer;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.regex.Pattern;
-import java.lang.instrument.Instrumentation;
 
 import javax.jms.JMSException;
 
@@ -61,7 +58,6 @@ import oracle.jms.AQjmsBytesMessage;
 import oracle.jms.AQjmsDestination;
 
 //import org.oracle.okafka.clients.consumer.OffsetResetStrategy;
-import org.oracle.okafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.ClientDnsLookup;
 import org.apache.kafka.clients.ClientUtils;
 //import org.oracle.okafka.clients.consumer.internals.PartitionAssignor;
@@ -107,7 +103,6 @@ import org.oracle.okafka.common.errors.InvalidLoginCredentialsException;
 import org.oracle.okafka.common.network.AQClient;
 import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.apache.kafka.common.internals.ClusterResourceListeners;
-import org.apache.kafka.common.metrics.Gauge;
 import org.apache.kafka.common.metrics.JmxReporter;
 import org.apache.kafka.common.metrics.MetricConfig;
 import org.apache.kafka.common.metrics.Metrics;
@@ -116,8 +111,6 @@ import org.apache.kafka.common.metrics.Sensor;
 import org.apache.kafka.common.metrics.stats.Avg;
 import org.apache.kafka.common.metrics.stats.Max;
 import org.apache.kafka.common.metrics.stats.Meter;
-import org.apache.kafka.common.metrics.stats.Min;
-import org.apache.kafka.common.metrics.stats.Value;
 import org.apache.kafka.common.metrics.stats.WindowedCount;
 import org.apache.kafka.common.record.TimestampType;
 import org.oracle.okafka.common.requests.IsolationLevel;

--- a/clients/src/main/java/org/oracle/okafka/clients/producer/internals/AQKafkaProducer.java
+++ b/clients/src/main/java/org/oracle/okafka/clients/producer/internals/AQKafkaProducer.java
@@ -380,7 +380,7 @@ public final class AQKafkaProducer extends AQClient {
 			}
 			else { 
 				//Create Empty or Invalid Offset
-				thisOffset= MessageIdConverter.getOKafkaOffset("",false,false);
+				thisOffset= MessageIdConverter.getOKafkaOffset(null,false,false);
 			}
 
 			produceResult = new ProduceRequestResult(tp);
@@ -476,7 +476,7 @@ public final class AQKafkaProducer extends AQClient {
 		}
 
 		do
-		{
+		{	
 			disconnected = false;
 			checkForCommit = false;
 			notALeader = false;
@@ -618,7 +618,11 @@ public final class AQKafkaProducer extends AQClient {
 							if( !stopReconnect && retryCnt > 0)
 							{
 								log.info("Reconnecting to node " + node);
+								Node copyNode = new Node(node);
 								boolean reCreate = nodePublishers.reCreate();
+								if(!node.equals(copyNode)) {
+									
+								}
 								if(!reCreate) {
 									log.info("Failed to reconnect to  " + node +" . Failing this batch for " + topicPartition);
 									disconnected = true;

--- a/clients/src/main/java/org/oracle/okafka/clients/producer/internals/AQKafkaProducer.java
+++ b/clients/src/main/java/org/oracle/okafka/clients/producer/internals/AQKafkaProducer.java
@@ -618,11 +618,7 @@ public final class AQKafkaProducer extends AQClient {
 							if( !stopReconnect && retryCnt > 0)
 							{
 								log.info("Reconnecting to node " + node);
-								Node copyNode = new Node(node);
 								boolean reCreate = nodePublishers.reCreate();
-								if(!node.equals(copyNode)) {
-									
-								}
 								if(!reCreate) {
 									log.info("Failed to reconnect to  " + node +" . Failing this batch for " + topicPartition);
 									disconnected = true;

--- a/clients/src/main/java/org/oracle/okafka/clients/producer/internals/SenderThread.java
+++ b/clients/src/main/java/org/oracle/okafka/clients/producer/internals/SenderThread.java
@@ -351,7 +351,6 @@ public class SenderThread implements Runnable {
 	 * basis
 	 */
 	private void sendProduceRequests(Map<Integer, List<ProducerBatch>> collated, long pollTimeout) {
-
 		for (Map.Entry<Integer, List<ProducerBatch>> entry : collated.entrySet()) {
 			sendProduceRequest(metadata.getNodeById(entry.getKey()), entry.getValue());
 		}

--- a/clients/src/main/java/org/oracle/okafka/clients/producer/internals/SenderThread.java
+++ b/clients/src/main/java/org/oracle/okafka/clients/producer/internals/SenderThread.java
@@ -39,18 +39,13 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 
-import javax.jms.JMSException;
-
 import org.apache.kafka.clients.ClientRequest;
 import org.apache.kafka.clients.ClientResponse;
 import org.oracle.okafka.clients.KafkaClient;
 import org.oracle.okafka.clients.Metadata;
 import org.apache.kafka.clients.RequestCompletionHandler;
 import org.oracle.okafka.common.requests.ProduceRequest;
-import org.oracle.okafka.clients.producer.KafkaProducer;
 import org.oracle.okafka.clients.producer.ProducerConfig;
-import org.oracle.okafka.clients.producer.internals.ProducerBatch;
-import org.oracle.okafka.clients.producer.internals.RecordAccumulator;
 import org.apache.kafka.clients.producer.internals.SenderMetricsRegistry;
 //import org.oracle.okafka.clients.producer.internals.SenderMetricsRegistry;
 import org.oracle.okafka.common.requests.ProduceResponse;

--- a/clients/src/main/java/org/oracle/okafka/common/Node.java
+++ b/clients/src/main/java/org/oracle/okafka/common/Node.java
@@ -70,10 +70,6 @@ public class Node  extends org.apache.kafka.common.Node{
     public Node(Node node) {
     	this(node.id(), node.host(), node.port(),node.serviceName(), node.instanceName());    	
     }
-    
-    public static Node getCopy(Node node) {
-    	return new Node(node.id, node.host, node.port, node.serviceName, node.instanceName);
-    }
 
     public boolean isEmpty() {
         return host == null || host.isEmpty() || port < 0 || serviceName.isEmpty() ;

--- a/clients/src/main/java/org/oracle/okafka/common/Node.java
+++ b/clients/src/main/java/org/oracle/okafka/common/Node.java
@@ -66,6 +66,14 @@ public class Node  extends org.apache.kafka.common.Node{
     public static Node noNode() {
         return NO_NODE;
     }
+    
+    public Node(Node node) {
+    	this(node.id(), node.host(), node.port(),node.serviceName(), node.instanceName());    	
+    }
+    
+    public static Node getCopy(Node node) {
+    	return new Node(node.id, node.host, node.port, node.serviceName, node.instanceName);
+    }
 
     public boolean isEmpty() {
         return host == null || host.isEmpty() || port < 0 || serviceName.isEmpty() ;
@@ -189,7 +197,7 @@ public class Node  extends org.apache.kafka.common.Node{
         
         Node other = (Node) obj;
         return (host== null ? other.host() == null : host.equals(other.host())) &&
-           // id == other.id() &&
+            id == other.id() &&
             port == other.port() &&          
             (serviceName == null ? other.serviceName() == null : serviceName.equals(other.serviceName())) &&
             (instanceName == null ? other.instanceName() == null : instanceName.equals(other.instanceName())); 


### PR DESCRIPTION
Done changes Ensuring that in case of wrong host/port/service/username/password the client return the error to the user without further retrying.
Handled a mutable Node (okafka) Key hashmap bugs in  NetworkClient's initiateConnect() method.